### PR TITLE
tools: change message for error code 6

### DIFF
--- a/pdfbrain/tools.py
+++ b/pdfbrain/tools.py
@@ -23,5 +23,5 @@ def get_error_message():
         3: 'Data format error',
         4: 'Incorrect password error',
         5: 'Unsupported security scheme error',
-        6: 'License authorization error',
+        6: 'Page not found or content error',
     }.get(err_code, f'Error code {err_code}')


### PR DESCRIPTION
According to the sources of PDFium, error code 6 is a `page not found or content error`.
This is one of the few differences between Foxit documentation and PDFium.
See https://pdfium.googlesource.com/pdfium/+/68a18a0c58d5601f1fefb9e6024c5b187c70bce1/public/fpdfview.h#580
vs. https://developers.foxit.com/resources/pdf-sdk/c_api_reference_pdfium/group___f_p_d_f_i_u_m.html#ga2f7052c6091f718d6a5926361ef92685