### PR TITLE
patch for using pypdfium2

### DIFF
--- a/pdfbrain/pdf_file.py
+++ b/pdfbrain/pdf_file.py
@@ -1,4 +1,4 @@
-import pypdfium as pdfium
+import pypdfium2 as pdfium
 from .tools import lazyproperty, get_error_message
 from .pdf_page import PDFPage
 

--- a/pdfbrain/pdf_page.py
+++ b/pdfbrain/pdf_page.py
@@ -1,6 +1,6 @@
 from PIL import Image
 from ctypes import c_float, byref, create_string_buffer, cast, POINTER, c_ubyte
-import pypdfium as pdfium
+import pypdfium2 as pdfium
 from .tools import lazyproperty, get_error_message
 from .pdf_text_page import PDFTextPage
 

--- a/pdfbrain/pdf_text_page.py
+++ b/pdfbrain/pdf_text_page.py
@@ -1,6 +1,6 @@
 from ctypes import POINTER, cast, byref, c_double, c_uint16
 import unicodedata
-import pypdfium as pdfium
+import pypdfium2 as pdfium
 from .tools import lazyproperty
 
 

--- a/pdfbrain/tools.py
+++ b/pdfbrain/tools.py
@@ -1,5 +1,5 @@
 import functools
-import pypdfium as pdfium
+import pypdfium2 as pdfium
 
 
 def lazyproperty(fn):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Pillow~=8.3.2
-pypdfium~=0.0.15
+pypdfium2


### PR DESCRIPTION
pypdfium2 is not published yet, but when it's out, you could consider switching, as that's where regular updates are planned. If you are only using the PDFium API, pypdfium2 should be fully compatible with the original pypdfium.