### PR TITLE
Fix random crashes on exit

### DIFF
--- a/pdfbrain/__init__.py
+++ b/pdfbrain/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 
 from .pdf_file import PDFFile
 from .pdf_page import PDFPage

--- a/pdfbrain/pdf_file.py
+++ b/pdfbrain/pdf_file.py
@@ -1,14 +1,23 @@
-import pypdfium as pdfium
+import pypdfium2 as pdfium
+import sys
 from .tools import lazyproperty, get_error_message
 from .pdf_page import PDFPage
+import weakref
 
 # this line is very important, otherwise it won't work
 pdfium.FPDF_InitLibraryWithConfig(pdfium.FPDF_LIBRARY_CONFIG(2, None, None, 0))
 
 
+def _close_file(fileref):
+    file = fileref()
+    if file:
+        file.close()
+
 class PDFFile:
-    def __init__(self, ptr):
+    def __init__(self, ptr, filename):
         self._ptr = ptr
+        self.filename = filename
+        weakref.finalize(self, _close_file, weakref.ref(self))
 
     @classmethod
     def load(cls, filename, password=None):
@@ -16,10 +25,18 @@ class PDFFile:
         if not ptr:
             err_message = get_error_message()
             raise RuntimeError(f'PDFFile.load: failed to load {filename}: {err_message}')
-        return cls(ptr)
+        return cls(ptr, filename)
 
-    def __del__(self):
-        pdfium.FPDF_CloseDocument(self._ptr)
+    def close(self):
+        if self._ptr:
+            pdfium.FPDF_CloseDocument(self._ptr)
+            self._ptr = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
 
     @lazyproperty
     def numpages(self):

--- a/pdfbrain/test/test_smoke.py
+++ b/pdfbrain/test/test_smoke.py
@@ -73,3 +73,11 @@ def test_search_flags():
     finder = text_page0.find('borin', match_whole_word=True)
     results = list(finder)
     assert len(results) == 0
+
+
+def test_page_label():
+    with PDFFile.load(res('bug_page_label.pdf')) as pdf:
+        assert len(pdf) == 24
+        assert pdf[0].label == '123'
+        assert pdf[22].label == '145'
+        assert pdf[23].label == ''

--- a/pdfbrain/test/test_smoke.py
+++ b/pdfbrain/test/test_smoke.py
@@ -16,6 +16,20 @@ def test_smoke():
     img = pdf[1].render()
     assert img.size == (612, 792)
 
+def test_with():
+    with PDFFile.load(res('simple.pdf')) as pdf:
+        assert len(pdf) == 2
+
+        page0 = pdf[0]
+        assert page0.label == ''
+        assert page0.media_box == (0.0, 0.0, 612.0, 792.0)
+        assert page0.crop_box == (0.0, 0.0, 612.0, 792.0)
+
+    pdf.close()  # should be NOOP
+    pdf.close()  # should be NOOP
+    pdf.close()  # should be NOOP
+
+
 def test_text():
     pagen0 = PDFFile.load(res('simple.pdf'))[0]
 

--- a/pdfbrain/tools.py
+++ b/pdfbrain/tools.py
@@ -1,5 +1,5 @@
 import functools
-import pypdfium as pdfium
+import pypdfium2 as pdfium
 
 
 def lazyproperty(fn):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Pillow~=8.3.2
-pypdfium~=0.0.15
+pypdfium2~=2.2.0


### PR DESCRIPTION
`__del__` object method is not guaranteed to be called in the refcount order when program exits. This caused random crashes at the exit of programms using `pdfbrain`. Fix is to use `weakref.finalize`, that has well-defined behavior at exit.

Also here: 
1. fixed page label logic (was one page off)
2. added tests for the page label
3. switched to a (better supported) `pypdfium2`